### PR TITLE
feat: deploy preview/test site to github pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -30,8 +30,11 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout source at tested commit
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0


### PR DESCRIPTION
Adds automated GitHub Pages deployment workflow that publishes the SDK documentation site after tests pass on master. Can also be triggered manually. Tested in my fork of the repo. Not intended to be the main hosted version (that will likely go on https://evo-sdk.dash.org/). This is for previewing/testing latest only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public documentation site is now published via GitHub Pages.

* **Documentation**
  * Documentation is automatically built and deployed after successful checks or via manual trigger.
  * Ensures up-to-date content with single concurrent deployment and basic validation before publish.
  * Deployment exposes the live documentation URL for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->