### PR TITLE
ci: open version update PR as draft if tests fail

### DIFF
--- a/.github/workflows/update-evo-sdk.yml
+++ b/.github/workflows/update-evo-sdk.yml
@@ -1,4 +1,4 @@
-name: Update evo-sdk version on npm release
+name: Check/Update SDK version
 
 on:
   workflow_dispatch:  # Manual trigger
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: '20'
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_version.outputs.needs_update == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           draft: ${{ steps.smoke_tests.outcome != 'success' || steps.query_tests.outcome != 'success' }}
           branch: update-deps/evo-sdk-${{ steps.check_version.outputs.latest }}


### PR DESCRIPTION
Updates the workflow to always open a PR when a new version of the SDK is available. If the tests don't pass, it sets the PR to draft and indicates which test set failed. Also pins the GitHub action versions by hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with improved test result reporting, displaying detailed outcomes of automated tests in pull requests for better visibility.
  * Implemented conditional draft pull request creation based on test results to prevent accidental merging when tests fail.
  * Optimized workflow configuration with updated action references and added direct links to workflow runs for easier debugging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->