### PR TITLE
feat: implement dark mode

### DIFF
--- a/public/docs.css
+++ b/public/docs.css
@@ -1,18 +1,20 @@
+@import url('theme.css');
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     line-height: 1.6;
-    color: #333;
+    color: var(--text-primary);
     margin: 0;
     padding: 0;
-    background-color: #f5f5f5;
+    background-color: var(--bg-primary);
     display: flex;
 }
 
 /* Sidebar styles */
 .sidebar {
     width: 280px;
-    background-color: white;
-    box-shadow: 2px 0 4px rgba(0,0,0,0.1);
+    background-color: var(--bg-secondary);
+    box-shadow: 2px 0 4px var(--shadow-light);
     position: fixed;
     height: 100vh;
     overflow-y: auto;
@@ -22,7 +24,7 @@ body {
 .sidebar h2 {
     font-size: 1.2em;
     margin-bottom: 10px;
-    color: #2c3e50;
+    color: var(--text-primary);
 }
 
 .sidebar ul {
@@ -36,7 +38,7 @@ body {
 }
 
 .sidebar a {
-    color: #34495e;
+    color: var(--text-secondary);
     text-decoration: none;
     font-size: 0.9em;
     display: block;
@@ -46,12 +48,12 @@ body {
 }
 
 .sidebar a:hover {
-    background-color: #ecf0f1;
-    color: #2c3e50;
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
 }
 
 .sidebar .section-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: var(--sidebar-section-gradient);
     color: white;
     padding: 12px 20px;
     margin: 20px -20px 15px -20px;
@@ -80,41 +82,43 @@ body {
 }
 
 .sidebar .section-header.state-transitions {
-    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+    background: var(--sidebar-section-alt-gradient);
 }
 
 .sidebar .category {
     font-weight: 600;
-    color: #34495e;
+    color: var(--text-secondary);
     margin-top: 15px;
     margin-bottom: 8px;
     font-size: 0.85em;
     padding-left: 10px;
-    border-left: 3px solid #3498db;
+    border-left: 3px solid var(--sidebar-category-border);
 }
 
 /* Search box styles */
 .search-container {
     padding: 0 20px 20px 20px;
-    border-bottom: 1px solid #ecf0f1;
+    border-bottom: 1px solid var(--border-subtle);
 }
 
 .search-input {
     width: 100%;
     padding: 8px 12px;
-    border: 1px solid #ddd;
+    border: 1px solid var(--border-light);
     border-radius: 4px;
     font-size: 0.9em;
     outline: none;
     transition: border-color 0.2s;
+    background-color: var(--bg-input);
+    color: var(--text-primary);
 }
 
 .search-input:focus {
-    border-color: #3498db;
+    border-color: var(--accent-secondary);
 }
 
 .search-input::placeholder {
-    color: #95a5a6;
+    color: var(--text-placeholder);
 }
 
 .sidebar li.hidden {
@@ -123,7 +127,7 @@ body {
 
 .sidebar .no-results {
     text-align: center;
-    color: #95a5a6;
+    color: var(--text-placeholder);
     padding: 20px;
     font-size: 0.9em;
     display: none;
@@ -137,31 +141,31 @@ body {
 }
 
 h1, h2, h3, h4 {
-    color: #2c3e50;
+    color: var(--text-primary);
 }
 
 h1 {
-    border-bottom: 3px solid #3498db;
+    border-bottom: 3px solid var(--accent-secondary);
     padding-bottom: 10px;
 }
 
 h2 {
-    border-bottom: 2px solid #ecf0f1;
+    border-bottom: 2px solid var(--border-subtle);
     padding-bottom: 8px;
     margin-top: 30px;
 }
 
 h3 {
-    color: #34495e;
+    color: var(--text-secondary);
     margin-top: 25px;
 }
 
 .nav {
-    background-color: white;
+    background-color: var(--bg-secondary);
     padding: 15px;
     border-radius: 8px;
     margin-bottom: 30px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px var(--shadow-light);
 }
 
 .nav ul {
@@ -176,7 +180,7 @@ h3 {
 }
 
 .nav a {
-    color: #3498db;
+    color: var(--accent-secondary);
     text-decoration: none;
     font-weight: 500;
 }
@@ -186,27 +190,27 @@ h3 {
 }
 
 .category {
-    background-color: white;
+    background-color: var(--bg-secondary);
     padding: 20px;
     border-radius: 8px;
     margin-bottom: 20px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 2px 4px var(--shadow-light);
 }
 
 .operation {
-    border-left: 4px solid #3498db;
+    border-left: 4px solid var(--operation-border);
     padding-left: 20px;
     margin-bottom: 30px;
 }
 
 .description {
-    color: #7f8c8d;
+    color: var(--description-color);
     font-style: italic;
     margin-bottom: 15px;
 }
 
 .parameters {
-    background-color: #ecf0f1;
+    background-color: var(--parameters-bg);
     padding: 15px;
     border-radius: 5px;
     margin-top: 10px;
@@ -215,7 +219,7 @@ h3 {
 .parameter {
     margin-bottom: 10px;
     padding: 5px 0;
-    border-bottom: 1px solid #bdc3c7;
+    border-bottom: 1px solid var(--parameters-border);
 }
 
 .parameter:last-child {
@@ -224,27 +228,27 @@ h3 {
 
 .param-name {
     font-weight: bold;
-    color: #2c3e50;
+    color: var(--text-primary);
 }
 
 .param-type {
-    color: #e74c3c;
+    color: var(--param-type-color);
     font-family: monospace;
     font-size: 0.9em;
 }
 
 .param-required {
-    color: #e74c3c;
+    color: var(--param-required-color);
     font-weight: bold;
 }
 
 .param-optional {
-    color: #95a5a6;
+    color: var(--param-optional-color);
 }
 
 .code-example {
-    background-color: #2c3e50;
-    color: #ecf0f1;
+    background-color: var(--bg-code);
+    color: var(--preloader-text);
     padding: 15px;
     border-radius: 5px;
     overflow-x: auto;
@@ -254,16 +258,16 @@ h3 {
 
 /* Interactive example styles */
 .example-container {
-    background-color: #f8f9fa;
-    border: 1px solid #dee2e6;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
     border-radius: 5px;
     padding: 15px;
     margin-top: 15px;
 }
 
 .example-code {
-    background-color: #2c3e50;
-    color: #ecf0f1;
+    background-color: var(--bg-code);
+    color: var(--preloader-text);
     padding: 10px;
     border-radius: 3px;
     font-family: monospace;
@@ -275,7 +279,7 @@ h3 {
 }
 
 .run-button {
-    background-color: #3498db;
+    background-color: var(--accent-secondary);
     color: white;
     border: none;
     padding: 8px 16px;
@@ -286,11 +290,11 @@ h3 {
 }
 
 .run-button:hover {
-    background-color: #2980b9;
+    background-color: var(--accent-secondary-hover);
 }
 
 .run-button:disabled {
-    background-color: #95a5a6;
+    background-color: var(--param-optional-color);
     cursor: not-allowed;
 }
 
@@ -304,15 +308,15 @@ h3 {
 }
 
 .example-result.success {
-    background-color: #d4edda;
-    border: 1px solid #c3e6cb;
-    color: #155724;
+    background-color: var(--success-bg);
+    border: 1px solid var(--success-border);
+    color: var(--success-text);
 }
 
 .example-result.error {
-    background-color: #f8d7da;
-    border: 1px solid #f5c6cb;
-    color: #721c24;
+    background-color: var(--error-banner-bg);
+    border: 1px solid var(--error-banner-border);
+    color: var(--error-banner-text);
 }
 
 .loading {
@@ -333,31 +337,42 @@ h3 {
     position: fixed;
     bottom: 20px;
     right: 20px;
-    background-color: #3498db;
+    background-color: var(--accent-secondary);
     color: white;
     padding: 10px 15px;
     border-radius: 5px;
     text-decoration: none;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 2px 4px var(--shadow-medium);
 }
 
 .back-to-top:hover {
-    background-color: #2980b9;
+    background-color: var(--accent-secondary-hover);
 }
 
 .info-note {
-    background-color: #e3f2fd;
-    color: #1565c0;
+    background-color: var(--info-bg);
+    color: var(--info-text);
     padding: 12px 16px;
     border-radius: 4px;
     font-size: 0.9em;
     margin: 10px 0;
-    border-left: 4px solid #1976d2;
+    border-left: 4px solid var(--info-border);
+}
+
+.info-note code {
+    background-color: var(--path-code-bg);
+    color: var(--text-primary);
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.docs-theme-toggle {
+    margin: 0 0 15px 0;
 }
 
 .path-info {
-    background-color: #f5f7fa;
-    border: 1px solid #e1e5eb;
+    background-color: var(--path-info-bg);
+    border: 1px solid var(--path-info-border);
     border-radius: 4px;
     padding: 15px;
     margin-top: 15px;
@@ -366,7 +381,7 @@ h3 {
 .path-info h6 {
     margin-top: 15px;
     margin-bottom: 10px;
-    color: #2c3e50;
+    color: var(--text-primary);
     font-size: 0.95em;
 }
 
@@ -381,20 +396,21 @@ h3 {
 }
 
 .path-table th {
-    background-color: #e9ecef;
+    background-color: var(--path-table-header-bg);
     padding: 8px 12px;
     text-align: left;
     font-weight: 600;
-    border: 1px solid #dee2e6;
+    border: 1px solid var(--path-table-border);
+    color: var(--text-primary);
 }
 
 .path-table td {
     padding: 8px 12px;
-    border: 1px solid #dee2e6;
+    border: 1px solid var(--path-table-border);
 }
 
 .path-table code {
-    background-color: #fff;
+    background-color: var(--path-code-bg);
     padding: 2px 6px;
     border-radius: 3px;
     font-family: monospace;
@@ -411,7 +427,7 @@ h3 {
 }
 
 .path-info li code {
-    background-color: #fff;
+    background-color: var(--path-code-bg);
     padding: 2px 6px;
     border-radius: 3px;
     font-family: monospace;
@@ -425,7 +441,7 @@ h3 {
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.8);
+    background-color: var(--preloader-overlay);
     z-index: 9999;
 }
 
@@ -437,16 +453,16 @@ h3 {
 
 .preloader-content {
     text-align: center;
-    background: white;
+    background: var(--preloader-bg);
     padding: 30px 50px;
     border-radius: 10px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 4px 6px var(--shadow-light);
 }
 
 .preloader-text {
     font-size: 16px;
     margin-bottom: 15px;
-    color: #333;
+    color: var(--preloader-text);
 }
 
 .preloader-progress {
@@ -456,7 +472,7 @@ h3 {
 .progress-bar {
     width: 300px;
     height: 20px;
-    background-color: #f0f0f0;
+    background-color: var(--progress-bg);
     border-radius: 10px;
     overflow: hidden;
     margin-bottom: 10px;
@@ -464,7 +480,7 @@ h3 {
 
 .progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, #4CAF50, #45a049);
+    background: var(--progress-fill);
     width: 0%;
     transition: width 0.3s ease;
 }
@@ -472,5 +488,5 @@ h3 {
 .progress-percent {
     font-size: 14px;
     font-weight: bold;
-    color: #333;
+    color: var(--progress-text);
 }

--- a/public/index.css
+++ b/public/index.css
@@ -1,17 +1,18 @@
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-  background-color: #f5f5f5;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 .header {
-  background-color: #2c3e50;
-  color: white;
+  background-color: var(--header-bg);
+  color: var(--header-text);
   padding: 15px 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px var(--shadow-light);
 }
 
 .header h1 {
@@ -23,18 +24,19 @@ body {
 .version-info {
   font-size: 14px;
   font-weight: normal;
-  color: #a0b3c7;
+  color: var(--header-text-muted);
   margin-left: 12px;
   opacity: 0.9;
 }
 
 .header-nav {
   display: flex;
+  align-items: center;
   gap: 20px;
 }
 
 .header-nav a {
-  color: white;
+  color: var(--header-text);
   text-decoration: none;
   font-weight: 500;
   transition: opacity 0.2s;
@@ -48,7 +50,7 @@ body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: var(--preloader-overlay);
   z-index: 1000;
   align-items: center;
   justify-content: center;
@@ -57,7 +59,7 @@ body {
 .preloader-content {
   width: min(420px, calc(100% - 40px));
   text-align: center;
-  background: #111827;
+  background: var(--preloader-bg);
   padding: 32px 40px;
   border-radius: 12px;
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
@@ -66,14 +68,14 @@ body {
 .preloader-text {
   font-size: 18px;
   margin-bottom: 18px;
-  color: #f9fafb;
+  color: var(--preloader-text);
   font-weight: 500;
 }
 
 .progress-bar {
   width: 100%;
   height: 18px;
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--progress-bg);
   border-radius: 999px;
   overflow: hidden;
   margin-bottom: 12px;
@@ -81,7 +83,7 @@ body {
 
 .progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, #4CAF50, #45a049);
+  background: var(--progress-fill);
   width: 0%;
   transition: width 0.3s ease;
   border-radius: 999px;
@@ -90,7 +92,7 @@ body {
 .progress-percent {
   font-size: 14px;
   font-weight: 600;
-  color: #a7f3d0;
+  color: var(--progress-text);
 }
 
 .app-container {
@@ -101,8 +103,8 @@ body {
 
 .sidebar {
   width: 450px;
-  background-color: white;
-  border-right: 1px solid #e0e0e0;
+  background-color: var(--bg-secondary);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -110,14 +112,14 @@ body {
 
 .network-toggle {
   padding: 20px;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #e0e0e0;
+  background-color: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .network-toggle label {
   margin-right: 15px;
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .network-indicator {
@@ -130,19 +132,19 @@ body {
 }
 
 .network-indicator.testnet {
-  background-color: #ff9800;
+  background-color: var(--warning);
   color: white;
 }
 
 .network-indicator.mainnet {
-  background-color: #4caf50;
+  background-color: var(--success);
   color: white;
 }
 
 .proof-toggle {
   padding: 15px 20px;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #e0e0e0;
+  background-color: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -150,7 +152,7 @@ body {
 
 .proof-toggle label {
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -174,7 +176,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: #ccc;
+  background-color: var(--toggle-off);
   transition: .4s;
   border-radius: 34px;
 }
@@ -186,13 +188,13 @@ body {
   width: 16px;
   left: 4px;
   bottom: 4px;
-  background-color: white;
+  background-color: var(--toggle-knob);
   transition: .4s;
   border-radius: 50%;
 }
 
 input:checked + .toggle-slider {
-  background-color: #4CAF50;
+  background-color: var(--toggle-on);
 }
 
 input:checked + .toggle-slider:before {
@@ -228,14 +230,15 @@ details.sdk-config summary span:last-child {
   width: 100%;
   padding: 10px;
   font-size: 14px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
-  background-color: white;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
   margin-bottom: 10px;
 }
 
 .query-inputs {
-  background-color: #f8f9fa;
+  background-color: var(--bg-tertiary);
   padding: 15px;
   border-radius: 8px;
   margin-bottom: 15px;
@@ -249,21 +252,23 @@ details.sdk-config summary span:last-child {
   display: block;
   margin-bottom: 5px;
   font-weight: 500;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .input-group input[type="text"],
 .input-group input[type="password"] {
   width: 100%;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   font-size: 14px;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .query-inputs h4 {
   margin: 0 0 15px 0;
-  color: #333;
+  color: var(--text-primary);
   font-size: 1em;
 }
 
@@ -274,7 +279,7 @@ details.sdk-config summary span:last-child {
 .input-group label {
   display: block;
   margin-bottom: 5px;
-  color: #555;
+  color: var(--text-secondary);
   font-size: 0.9em;
 }
 
@@ -282,10 +287,12 @@ details.sdk-config summary span:last-child {
 .input-group select {
   width: 100%;
   padding: 8px 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   font-size: 14px;
   box-sizing: border-box;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .input-group input[type="checkbox"] {
@@ -304,7 +311,7 @@ details.sdk-config summary span:last-child {
 }
 
 .optional-label {
-  color: #888;
+  color: var(--text-muted);
   font-size: 0.85em;
   font-style: italic;
 }
@@ -312,7 +319,7 @@ details.sdk-config summary span:last-child {
 .execute-button {
   width: 100%;
   padding: 12px;
-  background-color: #1976d2;
+  background-color: var(--accent-primary);
   color: white;
   border: none;
   border-radius: 4px;
@@ -323,17 +330,17 @@ details.sdk-config summary span:last-child {
 }
 
 .execute-button:hover {
-  background-color: #1565c0;
+  background-color: var(--accent-primary-hover);
 }
 
 .execute-button:disabled {
-  background-color: #ccc;
+  background-color: var(--toggle-off);
   cursor: not-allowed;
 }
 
 .result-container {
   flex: 1;
-  background-color: white;
+  background-color: var(--bg-secondary);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -352,32 +359,32 @@ details.sdk-config summary span:last-child {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .result-proof-section {
   border-bottom: none;
-  background-color: #f8f9fa;
+  background-color: var(--bg-tertiary);
 }
 
 .section-header {
   padding: 10px 20px;
-  background-color: #e3f2fd;
-  border-bottom: 1px solid #ccc;
+  background-color: var(--section-data-bg);
+  border-bottom: 1px solid var(--border-color);
   font-weight: 600;
-  color: #1976d2;
+  color: var(--section-data-text);
   font-size: 14px;
 }
 
 .result-proof-section .section-header {
-  background-color: #f3e5f5;
-  color: #7b1fa2;
+  background-color: var(--section-proof-bg);
+  color: var(--section-proof-text);
 }
 
 .result-header {
   padding: 20px;
-  background-color: #f8f9fa;
-  border-bottom: 1px solid #e0e0e0;
+  background-color: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -385,22 +392,23 @@ details.sdk-config summary span:last-child {
 
 .result-header h2 {
   margin: 0;
-  color: #333;
+  color: var(--text-primary);
   font-size: 1.3em;
 }
 
 .result-actions button {
   margin-left: 10px;
   padding: 8px 16px;
-  border: 1px solid #ddd;
-  background-color: white;
+  border: 1px solid var(--border-light);
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
   border-radius: 4px;
   cursor: pointer;
   font-size: 14px;
 }
 
 .result-actions button:hover {
-  background-color: #f5f5f5;
+  background-color: var(--bg-tertiary);
 }
 
 .result-content {
@@ -415,7 +423,7 @@ details.sdk-config summary span:last-child {
 }
 
 .result-content.empty {
-  color: #888;
+  color: var(--text-muted);
   font-style: italic;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 }
@@ -439,30 +447,30 @@ details.sdk-config summary span:last-child {
 }
 
 .status-banner.success {
-  background-color: #4caf50;
+  background-color: var(--success);
   color: white;
 }
 
 .status-banner.error {
-  background-color: #f44336;
+  background-color: var(--error);
   color: white;
 }
 
 .status-banner.loading {
-  background-color: #ff9800;
+  background-color: var(--warning);
   color: white;
 }
 
 .error-result {
-  color: #d32f2f;
-  background-color: #ffebee;
-  border: 1px solid #ffcdd2;
+  color: var(--error-text);
+  background-color: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 4px;
   padding: 10px;
 }
 
 .credits-value {
-  color: #1976d2;
+  color: var(--accent-primary);
   cursor: help;
   text-decoration: underline;
   text-decoration-style: dotted;
@@ -471,7 +479,7 @@ details.sdk-config summary span:last-child {
 }
 
 .credits-value:hover {
-  background-color: #e3f2fd;
+  background-color: var(--credits-hover-bg);
   border-radius: 3px;
   padding: 0 2px;
 }
@@ -482,8 +490,8 @@ details.sdk-config summary span:last-child {
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
-  background-color: #333;
-  color: white;
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-text);
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 12px;
@@ -500,13 +508,13 @@ details.sdk-config summary span:last-child {
 }
 
 .nonce-value {
-  color: #9c27b0;
+  color: var(--nonce-color);
   cursor: help;
   position: relative;
 }
 
 .nonce-value:hover {
-  background-color: #f3e5f5;
+  background-color: var(--nonce-hover-bg);
   border-radius: 3px;
   padding: 0 2px;
 }
@@ -518,8 +526,8 @@ details.sdk-config summary span:last-child {
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);
-  background-color: #333;
-  color: white;
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-text);
   padding: 10px;
   border-radius: 4px;
   font-size: 12px;
@@ -531,7 +539,7 @@ details.sdk-config summary span:last-child {
   margin-bottom: 5px;
   z-index: 1000;
   max-width: 500px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 10px var(--shadow-medium);
 }
 
 .nonce-value:hover::after {
@@ -539,7 +547,7 @@ details.sdk-config summary span:last-child {
 }
 
 .json-key {
-  color: #d73a49;
+  color: var(--json-key);
   font-weight: 500;
 }
 
@@ -556,10 +564,10 @@ details.sdk-config summary span:last-child {
 }
 
 .array-input-container {
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   padding: 10px;
-  background-color: #fafafa;
+  background-color: var(--array-bg);
 }
 
 .array-item {
@@ -574,7 +582,7 @@ details.sdk-config summary span:last-child {
 
 .array-item button {
   padding: 5px 10px;
-  background-color: #ff5252;
+  background-color: var(--array-remove-btn);
   color: white;
   border: none;
   border-radius: 3px;
@@ -583,7 +591,7 @@ details.sdk-config summary span:last-child {
 
 .add-array-item {
   padding: 5px 15px;
-  background-color: #4caf50;
+  background-color: var(--array-add-btn);
   color: white;
   border: none;
   border-radius: 3px;
@@ -593,10 +601,10 @@ details.sdk-config summary span:last-child {
 
 .query-description {
   font-size: 0.85em;
-  color: #666;
+  color: var(--text-tertiary);
   margin-bottom: 15px;
   padding: 10px;
-  background-color: #e3f2fd;
+  background-color: var(--info-bg);
   border-radius: 4px;
   line-height: 1.4;
 }
@@ -613,7 +621,7 @@ select option:disabled {
 
 .action-button {
   padding: 8px 16px;
-  background-color: #2196f3;
+  background-color: var(--accent-secondary);
   color: white;
   border: none;
   border-radius: 4px;
@@ -622,22 +630,130 @@ select option:disabled {
 }
 
 .action-button:hover {
-  background-color: #1976d2;
+  background-color: var(--accent-primary);
 }
 
 .dynamic-fields-container {
   margin-top: 10px;
   padding: 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
-  background-color: #fafafa;
+  background-color: var(--dynamic-fields-bg);
 }
 
 .field-group {
   margin-bottom: 10px;
   padding: 8px;
-  background-color: white;
+  background-color: var(--field-group-bg);
   border-radius: 4px;
+}
+
+/* SDK Configuration section */
+.sdk-config {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.sdk-config summary {
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.sdk-config summary span {
+  color: var(--text-primary);
+}
+
+.sdk-config summary span:last-child {
+  color: var(--text-muted);
+}
+
+.sdk-config > div {
+  background-color: var(--bg-tertiary);
+}
+
+.sdk-config label {
+  color: var(--text-primary);
+}
+
+.sdk-config small {
+  color: var(--text-muted);
+}
+
+.sdk-config input,
+.sdk-config select {
+  background-color: var(--bg-input);
+  color: var(--text-primary);
+  border: 1px solid var(--border-light);
+}
+
+.sdk-config input::placeholder {
+  color: var(--text-placeholder);
+}
+
+.sdk-config details summary {
+  color: var(--text-primary);
+}
+
+.sdk-config #latestVersionInfo {
+  color: var(--text-secondary);
+}
+
+.sdk-config #applyConfig {
+  background-color: var(--accent-primary);
+  color: white;
+}
+
+.sdk-config #applyConfig:hover {
+  background-color: var(--accent-primary-hover);
+}
+
+/* Nested details in SDK config (Request Settings) */
+.sdk-config details {
+  background-color: transparent;
+}
+
+.sdk-config details > div {
+  padding-left: 10px;
+  border-left: 2px solid var(--border-color);
+  margin-left: 5px;
+}
+
+/* Proof toggle label */
+.proof-toggle span[style*="color: #333"] {
+  color: var(--text-primary) !important;
+}
+
+/* No proof info container */
+.no-proof-info {
+  background-color: var(--bg-tertiary) !important;
+  border-color: var(--border-color) !important;
+}
+
+.no-proof-info span {
+  color: var(--text-muted) !important;
+}
+
+/* API Error Banner for dark mode */
+.api-error-banner {
+  background-color: var(--error-banner-bg);
+  color: var(--error-banner-text);
+  padding: 15px;
+  margin: 0;
+  border-bottom: 1px solid var(--error-banner-border);
+  text-align: center;
+}
+
+.api-retry-button {
+  background-color: var(--error);
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.api-retry-button:hover {
+  opacity: 0.9;
 }
 
 .field-group label {
@@ -654,8 +770,8 @@ select option:disabled {
 
 .operator-select {
   width: 80px;
-  background-color: white;
-  color: #333;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
   padding: 8px 35px 8px 10px;
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -672,12 +788,12 @@ select option:disabled {
 }
 
 .operator-select option {
-  background-color: white;
-  color: #333;
+  background-color: var(--bg-input);
+  color: var(--text-primary);
 }
 
 .operator-select option:checked {
-  background-color: #007bff;
+  background-color: var(--accent-primary);
   color: white;
 }
 
@@ -697,24 +813,24 @@ select option:disabled {
 }
 
 .index-property-first {
-  background-color: #4caf50;
+  background-color: var(--badge-first);
   color: white;
 }
 
 .index-property-second {
-  background-color: #2196f3;
+  background-color: var(--badge-second);
   color: white;
 }
 
 .index-property-third {
-  background-color: #ff9800;
+  background-color: var(--badge-third);
   color: white;
 }
 
 .compound-index-warning {
-  background-color: #fff3cd;
-  border: 1px solid #ffeaa7;
-  color: #856404;
+  background-color: var(--compound-warning-bg);
+  border: 1px solid var(--compound-warning-border);
+  color: var(--compound-warning-text);
   padding: 10px;
   border-radius: 4px;
   margin: 10px 0;
@@ -722,8 +838,8 @@ select option:disabled {
 }
 
 .query-preview {
-  background-color: #f5f5f5;
-  border: 1px solid #ddd;
+  background-color: var(--bg-tertiary);
+  border: 1px solid var(--border-light);
   padding: 10px;
   border-radius: 4px;
   margin-top: 15px;
@@ -733,33 +849,33 @@ select option:disabled {
 
 .query-preview h5 {
   margin-top: 0;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .operator-help {
   font-size: 0.85em;
-  color: #666;
+  color: var(--text-tertiary);
   margin-left: 5px;
   cursor: help;
 }
 
 .range-group {
-  border: 1px solid #e0e0e0;
+  border: 1px solid var(--border-color);
   padding: 10px;
   border-radius: 4px;
   margin-bottom: 10px;
-  background-color: #f9f9f9;
+  background-color: var(--range-bg);
 }
 
 .range-group-header {
   font-weight: 500;
   margin-bottom: 8px;
-  color: #1976d2;
+  color: var(--range-header);
 }
 
 .add-range-button {
   padding: 4px 12px;
-  background-color: #1976d2;
+  background-color: var(--accent-primary);
   color: white;
   border: none;
   border-radius: 3px;
@@ -769,27 +885,27 @@ select option:disabled {
 }
 
 .add-range-button:hover {
-  background-color: #1565c0;
+  background-color: var(--accent-primary-hover);
 }
 
 .between-info {
-  background-color: #e3f2fd;
+  background-color: var(--between-bg);
   padding: 8px;
   border-radius: 3px;
   margin-top: 8px;
   font-size: 0.85em;
-  color: #1565c0;
+  color: var(--between-text);
 }
 
 .validation-error {
-  color: #d32f2f;
+  color: var(--error-text);
   font-size: 0.85em;
   margin-top: 5px;
 }
 
 .field-type-indicator {
   font-size: 0.8em;
-  color: #666;
+  color: var(--text-tertiary);
   margin-left: 5px;
   font-style: italic;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,15 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="theme-color" content="#2c3e50">
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' https://media.dash.org data:; connect-src 'self' https:">
   <title>Dash Platform Evo JS SDK</title>
   <link rel="icon" type="image/svg+xml" href="https://media.dash.org/wp-content/uploads/blue-d.svg">
   <link rel="alternate icon" type="image/png" href="https://media.dash.org/wp-content/uploads/blue-d-250.png">
+  <link rel="stylesheet" href="theme.css">
   <link rel="stylesheet" href="index.css">
+  <script src="theme.js"></script>
 </head>
 
 <body>
@@ -24,16 +27,15 @@
       <a href="docs.html">Documentation</a>
       <a href="AI_REFERENCE.md">AI Reference</a>
       <a href="https://github.com/dashpay/evo-sdk-website" target="_blank">GitHub</a>
+      <div id="themeToggle"></div>
     </nav>
   </div>
 
   <!-- Error Banner for API definitions loading failures -->
-  <div id="apiErrorBanner"
-    style="display: none; background-color: #f8d7da; color: #721c24; padding: 15px; margin: 0; border-bottom: 1px solid #f5c6cb; text-align: center;">
+  <div id="apiErrorBanner" class="api-error-banner" style="display: none;">
     <div style="display: flex; justify-content: center; align-items: center; gap: 15px; flex-wrap: wrap;">
       <span id="apiErrorMessage">Failed to load API definitions. Please check your connection and try again.</span>
-      <button id="apiRetryButton"
-        style="background-color: #dc3545; color: white; border: none; padding: 8px 16px; border-radius: 4px; cursor: pointer; font-size: 14px;">Retry</button>
+      <button id="apiRetryButton" class="api-retry-button">Retry</button>
     </div>
   </div>
 
@@ -66,20 +68,19 @@
       </div>
 
       <!-- SDK Configuration Section (Collapsible) -->
-      <details class="sdk-config" style="margin: 0; padding: 0; border-bottom: 1px solid #e0e0e0;">
-        <summary
-          style="padding: 15px 20px; background-color: #f8f9fa; cursor: pointer; list-style: none; display: flex; justify-content: space-between; align-items: center;">
-          <span style="font-weight: 500; color: #333;">Advanced SDK Configuration</span>
-          <span style="font-size: 0.8em; color: #666;">▼</span>
+      <details class="sdk-config" style="margin: 0; padding: 0;">
+        <summary style="padding: 15px 20px; cursor: pointer; list-style: none; display: flex; justify-content: space-between; align-items: center;">
+          <span style="font-weight: 500;">Advanced SDK Configuration</span>
+          <span style="font-size: 0.8em;">▼</span>
         </summary>
-        <div style="padding: 15px 20px; background-color: #f0f4f8;">
+        <div style="padding: 15px 20px;">
           <div style="margin-bottom: 10px;">
             <label style="display: block; margin-bottom: 5px; font-weight: 500;">Platform Version:</label>
             <div style="display: flex; gap: 10px; align-items: center;">
               <input type="number" id="platformVersion" placeholder="Latest" style="flex: 1; padding: 5px;" min="1">
-              <span id="latestVersionInfo" style="font-size: 0.9em; color: #666;"></span>
+              <span id="latestVersionInfo" style="font-size: 0.9em;"></span>
             </div>
-            <small style="color: #666;">Leave empty for latest version</small>
+            <small>Leave empty for latest version</small>
           </div>
 
           <details style="margin-top: 10px;">
@@ -104,9 +105,7 @@
             </div>
           </details>
 
-          <button id="applyConfig"
-            style="margin-top: 15px; padding: 8px 15px; background-color: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer; width: 100%;">Apply
-            Configuration</button>
+          <button id="applyConfig" style="margin-top: 15px; padding: 8px 15px; color: white; border: none; border-radius: 4px; cursor: pointer; width: 100%;">Apply Configuration</button>
         </div>
       </details>
 
@@ -157,15 +156,12 @@
               <input type="checkbox" id="proofToggle">
               <span class="toggle-slider"></span>
             </span>
-            <span style="margin-left: 60px; font-weight: 500; color: #333;">With Proof Info</span>
+            <span style="margin-left: 60px; font-weight: 500;">With Proof Info</span>
           </label>
         </div>
 
-        <div class="no-proof-info"
-          style="display: none; margin: 15px 0; padding: 10px; background-color: #f8f9fa; border: 1px solid #e9ecef; border-radius: 4px; text-align: center;"
-          id="noProofInfoContainer">
-          <span style="color: #6c757d; font-size: 0.9em;">Note: this query does not provide cryptographic proof
-            verification.</span>
+        <div class="no-proof-info" style="display: none; margin: 15px 0; padding: 10px; border-radius: 4px; text-align: center;" id="noProofInfoContainer">
+          <span style="font-size: 0.9em;">Note: this query does not provide cryptographic proof verification.</span>
         </div>
 
         <button id="executeQuery" class="execute-button" style="display: none;">Execute</button>
@@ -191,7 +187,6 @@
   <div id="statusBanner" class="status-banner loading">Initializing Evo SDK...</div>
 
   <script type="module" src="./app.js"></script>
-
 </body>
 
 </html>

--- a/public/theme.css
+++ b/public/theme.css
@@ -1,0 +1,451 @@
+/* Theme CSS Variables */
+:root {
+  /* Light mode (default) */
+  --bg-primary: #f5f5f5;
+  --bg-secondary: white;
+  --bg-tertiary: #f8f9fa;
+  --bg-input: white;
+  --bg-code: #2c3e50;
+
+  --text-primary: #333;
+  --text-secondary: #555;
+  --text-tertiary: #666;
+  --text-muted: #888;
+  --text-placeholder: #95a5a6;
+
+  --border-color: #e0e0e0;
+  --border-light: #ddd;
+  --border-subtle: #ecf0f1;
+
+  --header-bg: #2c3e50;
+  --header-text: white;
+  --header-text-muted: #a0b3c7;
+
+  --accent-primary: #1976d2;
+  --accent-primary-hover: #1565c0;
+  --accent-secondary: #3498db;
+  --accent-secondary-hover: #2980b9;
+
+  --success: #4caf50;
+  --success-bg: #d4edda;
+  --success-border: #c3e6cb;
+  --success-text: #155724;
+
+  --warning: #ff9800;
+
+  --error: #f44336;
+  --error-bg: #ffebee;
+  --error-border: #ffcdd2;
+  --error-text: #d32f2f;
+  --error-banner-bg: #f8d7da;
+  --error-banner-border: #f5c6cb;
+  --error-banner-text: #721c24;
+
+  --info-bg: #e3f2fd;
+  --info-border: #1976d2;
+  --info-text: #1565c0;
+
+  --section-data-bg: #e3f2fd;
+  --section-data-text: #1976d2;
+  --section-proof-bg: #f3e5f5;
+  --section-proof-text: #7b1fa2;
+
+  --toggle-off: #ccc;
+  --toggle-on: #4CAF50;
+  --toggle-knob: white;
+
+  --shadow-light: rgba(0, 0, 0, 0.1);
+  --shadow-medium: rgba(0, 0, 0, 0.2);
+
+  --json-key: #d73a49;
+  --credits-hover-bg: #e3f2fd;
+  --nonce-color: #9c27b0;
+  --nonce-hover-bg: #f3e5f5;
+
+  --preloader-overlay: rgba(0, 0, 0, 0.8);
+  --preloader-bg: #111827;
+  --preloader-text: #f9fafb;
+  --progress-bg: rgba(255, 255, 255, 0.12);
+  --progress-fill: linear-gradient(90deg, #4CAF50, #45a049);
+  --progress-text: #a7f3d0;
+
+  /* Docs specific */
+  --sidebar-category-border: #3498db;
+  --sidebar-section-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  --sidebar-section-alt-gradient: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+  --operation-border: #3498db;
+  --param-type-color: #e74c3c;
+  --param-required-color: #e74c3c;
+  --param-optional-color: #95a5a6;
+  --description-color: #7f8c8d;
+  --parameters-bg: #ecf0f1;
+  --parameters-border: #bdc3c7;
+  --path-info-bg: #f5f7fa;
+  --path-info-border: #e1e5eb;
+  --path-table-header-bg: #e9ecef;
+  --path-table-border: #dee2e6;
+  --path-code-bg: #fff;
+
+  /* Index property badges */
+  --badge-first: #4caf50;
+  --badge-second: #2196f3;
+  --badge-third: #ff9800;
+
+  /* Compound index warning */
+  --compound-warning-bg: #fff3cd;
+  --compound-warning-border: #ffeaa7;
+  --compound-warning-text: #856404;
+
+  /* Range group */
+  --range-bg: #f9f9f9;
+  --range-header: #1976d2;
+
+  /* Between info */
+  --between-bg: #e3f2fd;
+  --between-text: #1565c0;
+
+  /* Array input */
+  --array-bg: #fafafa;
+  --array-remove-btn: #ff5252;
+  --array-add-btn: #4caf50;
+
+  /* Dynamic fields */
+  --dynamic-fields-bg: #fafafa;
+  --field-group-bg: white;
+
+  /* Tooltip */
+  --tooltip-bg: #333;
+  --tooltip-text: white;
+}
+
+/* Dark mode */
+:root[data-theme="dark"] {
+  --bg-primary: #0f0f14;
+  --bg-secondary: #1a1a24;
+  --bg-tertiary: #252532;
+  --bg-input: #2a2a3a;
+  --bg-code: #0d0d12;
+
+  --text-primary: #f0f0f5;
+  --text-secondary: #b8b8c8;
+  --text-tertiary: #9090a0;
+  --text-muted: #707080;
+  --text-placeholder: #606070;
+
+  --border-color: #3a3a4a;
+  --border-light: #454558;
+  --border-subtle: #2f2f3f;
+
+  --header-bg: #1a1a24;
+  --header-text: #f0f0f5;
+  --header-text-muted: #9090a0;
+
+  --accent-primary: #6ea8fe;
+  --accent-primary-hover: #5090e0;
+  --accent-secondary: #6ea8fe;
+  --accent-secondary-hover: #5090e0;
+
+  --success: #4ade80;
+  --success-bg: #14532d;
+  --success-border: #22c55e;
+  --success-text: #86efac;
+
+  --warning: #fbbf24;
+
+  --error: #f87171;
+  --error-bg: #3f1515;
+  --error-border: #dc2626;
+  --error-text: #fca5a5;
+  --error-banner-bg: #3f1515;
+  --error-banner-border: #dc2626;
+  --error-banner-text: #fca5a5;
+
+  --info-bg: #1e3a5f;
+  --info-border: #6ea8fe;
+  --info-text: #a5c8ff;
+
+  --section-data-bg: #1e2d4a;
+  --section-data-text: #6ea8fe;
+  --section-proof-bg: #3a1f4a;
+  --section-proof-text: #d8b4fe;
+
+  --toggle-off: #4a4a5a;
+  --toggle-on: #4ade80;
+  --toggle-knob: #f0f0f5;
+
+  --shadow-light: rgba(0, 0, 0, 0.4);
+  --shadow-medium: rgba(0, 0, 0, 0.6);
+
+  --json-key: #ff7b93;
+  --credits-hover-bg: #1e3a5f;
+  --nonce-color: #d8b4fe;
+  --nonce-hover-bg: #3a1f4a;
+
+  --preloader-overlay: rgba(0, 0, 0, 0.92);
+  --preloader-bg: #1a1a24;
+  --preloader-text: #f0f0f5;
+  --progress-bg: rgba(255, 255, 255, 0.08);
+  --progress-fill: linear-gradient(90deg, #4ade80, #22c55e);
+  --progress-text: #86efac;
+
+  /* Docs specific */
+  --sidebar-category-border: #6ea8fe;
+  --sidebar-section-gradient: linear-gradient(135deg, #5b4cd9 0%, #7c3aed 100%);
+  --sidebar-section-alt-gradient: linear-gradient(135deg, #db2777 0%, #e11d48 100%);
+  --operation-border: #6ea8fe;
+  --param-type-color: #ff7b93;
+  --param-required-color: #ff7b93;
+  --param-optional-color: #707080;
+  --description-color: #9090a0;
+  --parameters-bg: #252532;
+  --parameters-border: #3a3a4a;
+  --path-info-bg: #252532;
+  --path-info-border: #3a3a4a;
+  --path-table-header-bg: #2a2a3a;
+  --path-table-border: #3a3a4a;
+  --path-code-bg: #1a1a24;
+
+  /* Index property badges */
+  --badge-first: #4ade80;
+  --badge-second: #6ea8fe;
+  --badge-third: #fbbf24;
+
+  /* Compound index warning */
+  --compound-warning-bg: #3f2a06;
+  --compound-warning-border: #a16207;
+  --compound-warning-text: #fcd34d;
+
+  /* Range group */
+  --range-bg: #252532;
+  --range-header: #6ea8fe;
+
+  /* Between info */
+  --between-bg: #1e3a5f;
+  --between-text: #a5c8ff;
+
+  /* Array input */
+  --array-bg: #252532;
+  --array-remove-btn: #f87171;
+  --array-add-btn: #4ade80;
+
+  /* Dynamic fields */
+  --dynamic-fields-bg: #252532;
+  --field-group-bg: #1a1a24;
+
+  /* Tooltip */
+  --tooltip-bg: #2a2a3a;
+  --tooltip-text: #f0f0f5;
+}
+
+/* Theme toggle button styles */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: var(--header-text);
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.theme-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.theme-toggle-icon {
+  width: 18px;
+  height: 18px;
+}
+
+/* Theme toggle container */
+#themeToggle {
+  display: flex;
+  align-items: center;
+}
+
+/* Theme selector dropdown */
+.theme-selector {
+  position: relative;
+  display: inline-flex;
+}
+
+.theme-selector-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: var(--header-text, white);
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.theme-selector-btn:hover {
+  background-color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.theme-btn-icon svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+.theme-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  background: var(--bg-secondary, white);
+  border: 1px solid var(--border-color, #e0e0e0);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px var(--shadow-medium, rgba(0,0,0,0.15));
+  min-width: 140px;
+  z-index: 1001;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transition: all 0.2s;
+  overflow: hidden;
+}
+
+.theme-dropdown.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.theme-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary, #333);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  appearance: none;
+  -webkit-appearance: none;
+  transition: background-color 0.15s;
+}
+
+.theme-option:hover {
+  background-color: var(--bg-tertiary, #f5f5f5);
+}
+
+.theme-option.active {
+  background-color: var(--info-bg, #e3f2fd);
+  color: var(--info-text, #1565c0);
+}
+
+.theme-option-icon {
+  width: 16px;
+  height: 16px;
+  opacity: 1;
+  flex-shrink: 0;
+}
+
+/* Smooth transitions for theme changes */
+body,
+.sidebar,
+.result-container,
+.header,
+.query-inputs,
+.result-content,
+input,
+select,
+button,
+.status-banner,
+.nav,
+.category,
+.parameters,
+.example-code,
+.example-container,
+.code-example,
+.preloader-content {
+  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+/* Docs page theme toggle (in sidebar) */
+.sidebar .theme-selector-btn {
+  border-color: var(--border-light);
+  color: var(--text-primary);
+  padding: 4px 10px;
+  font-size: 13px;
+}
+
+.sidebar .theme-selector-btn:hover {
+  background-color: var(--bg-tertiary);
+  border-color: var(--border-color);
+}
+
+.sidebar .theme-btn-label {
+  display: none;
+}
+
+@media (min-width: 350px) {
+  .sidebar .theme-btn-label {
+    display: inline;
+  }
+}
+
+/* Dark mode specific enhancements */
+[data-theme="dark"] .sidebar {
+  border-right-color: var(--border-color);
+}
+
+[data-theme="dark"] .result-container {
+  border-left: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] .header {
+  border-bottom: 1px solid var(--border-color);
+}
+
+[data-theme="dark"] input,
+[data-theme="dark"] select {
+  border-color: var(--border-light);
+}
+
+[data-theme="dark"] input:focus,
+[data-theme="dark"] select:focus {
+  border-color: var(--accent-primary);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(110, 168, 254, 0.2);
+}
+
+[data-theme="dark"] .result-actions button {
+  border-color: var(--border-light);
+}
+
+[data-theme="dark"] .result-actions button:hover {
+  background-color: var(--bg-tertiary);
+  border-color: var(--accent-primary);
+}
+
+/* Form elements in dark mode */
+[data-theme="dark"] input[type="radio"],
+[data-theme="dark"] input[type="checkbox"] {
+  accent-color: var(--accent-primary);
+}
+
+[data-theme="dark"] ::placeholder {
+  color: var(--text-placeholder);
+  opacity: 1;
+}
+
+[data-theme="dark"] option {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+}

--- a/public/theme.js
+++ b/public/theme.js
@@ -1,0 +1,280 @@
+/**
+ * Theme management for Dash Platform Evo JS SDK website
+ * Supports: light, dark, and system (auto) modes
+ */
+
+const THEME_KEY = 'evo-sdk-theme';
+const THEMES = {
+  LIGHT: 'light',
+  DARK: 'dark',
+  SYSTEM: 'system'
+};
+
+// SVG icons for theme options
+const ICONS = {
+  sun: `<svg class="theme-option-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>`,
+  moon: `<svg class="theme-option-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>`,
+  system: `<svg class="theme-option-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="2" y="3" width="20" height="14" rx="2" ry="2"></rect>
+    <line x1="8" y1="21" x2="16" y2="21"></line>
+    <line x1="12" y1="17" x2="12" y2="21"></line>
+  </svg>`
+};
+
+/**
+ * Get the system's preferred color scheme
+ */
+function getSystemTheme() {
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return THEMES.DARK;
+  }
+  return THEMES.LIGHT;
+}
+
+/**
+ * Get the stored theme preference
+ */
+function getStoredTheme() {
+  try {
+    return localStorage.getItem(THEME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store theme preference
+ */
+function storeTheme(theme) {
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Get the effective theme to apply
+ */
+function getEffectiveTheme(preference) {
+  if (preference === THEMES.SYSTEM || !preference) {
+    return getSystemTheme();
+  }
+  return preference;
+}
+
+/**
+ * Apply theme to document
+ */
+function applyTheme(theme) {
+  const effectiveTheme = getEffectiveTheme(theme);
+  document.documentElement.setAttribute('data-theme', effectiveTheme);
+
+  // Update meta theme-color for mobile browsers
+  const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+  if (metaThemeColor) {
+    metaThemeColor.setAttribute('content', effectiveTheme === THEMES.DARK ? '#0f3460' : '#2c3e50');
+  }
+}
+
+/**
+ * Initialize theme on page load
+ */
+function initTheme() {
+  const storedTheme = getStoredTheme() || THEMES.SYSTEM;
+  applyTheme(storedTheme);
+  return storedTheme;
+}
+
+/**
+ * Set up system theme change listener
+ */
+function setupSystemThemeListener(callback) {
+  if (window.matchMedia) {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => {
+      const storedTheme = getStoredTheme();
+      if (storedTheme === THEMES.SYSTEM || !storedTheme) {
+        applyTheme(THEMES.SYSTEM);
+        if (callback) callback(THEMES.SYSTEM);
+      }
+    };
+
+    // Modern browsers
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handler);
+    } else {
+      // Legacy support
+      mediaQuery.addListener(handler);
+    }
+  }
+}
+
+/**
+ * Create and inject theme selector UI
+ */
+function createThemeSelector(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  const currentTheme = getStoredTheme() || THEMES.SYSTEM;
+
+  const selector = document.createElement('div');
+  selector.className = 'theme-selector';
+  selector.innerHTML = `
+    <button class="theme-selector-btn" aria-label="Select theme" aria-haspopup="true" aria-expanded="false">
+      <span class="theme-btn-icon">${getIconForTheme(currentTheme)}</span>
+      <span class="theme-btn-label">${getLabelForTheme(currentTheme)}</span>
+    </button>
+    <div class="theme-dropdown" role="menu">
+      <button class="theme-option ${currentTheme === THEMES.LIGHT ? 'active' : ''}" data-theme="${THEMES.LIGHT}" role="menuitem">
+        ${ICONS.sun}
+        <span>Light</span>
+      </button>
+      <button class="theme-option ${currentTheme === THEMES.DARK ? 'active' : ''}" data-theme="${THEMES.DARK}" role="menuitem">
+        ${ICONS.moon}
+        <span>Dark</span>
+      </button>
+      <button class="theme-option ${currentTheme === THEMES.SYSTEM ? 'active' : ''}" data-theme="${THEMES.SYSTEM}" role="menuitem">
+        ${ICONS.system}
+        <span>System</span>
+      </button>
+    </div>
+  `;
+
+  container.appendChild(selector);
+
+  // Set up event listeners
+  const btn = selector.querySelector('.theme-selector-btn');
+  const dropdown = selector.querySelector('.theme-dropdown');
+  const options = selector.querySelectorAll('.theme-option');
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = dropdown.classList.contains('open');
+    dropdown.classList.toggle('open');
+    btn.setAttribute('aria-expanded', !isOpen);
+  });
+
+  options.forEach(option => {
+    option.addEventListener('click', () => {
+      const theme = option.dataset.theme;
+      setTheme(theme, selector);
+      dropdown.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    });
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener('click', () => {
+    dropdown.classList.remove('open');
+    btn.setAttribute('aria-expanded', 'false');
+  });
+
+  // Keyboard navigation
+  btn.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      dropdown.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  return selector;
+}
+
+/**
+ * Set theme and update UI
+ */
+function setTheme(theme, selectorElement) {
+  storeTheme(theme);
+  applyTheme(theme);
+
+  if (selectorElement) {
+    // Update button display
+    const btnIcon = selectorElement.querySelector('.theme-btn-icon');
+    const btnLabel = selectorElement.querySelector('.theme-btn-label');
+    if (btnIcon) btnIcon.innerHTML = getIconForTheme(theme);
+    if (btnLabel) btnLabel.textContent = getLabelForTheme(theme);
+
+    // Update active state
+    const options = selectorElement.querySelectorAll('.theme-option');
+    options.forEach(opt => {
+      opt.classList.toggle('active', opt.dataset.theme === theme);
+    });
+  }
+}
+
+/**
+ * Get icon for theme
+ */
+function getIconForTheme(theme) {
+  switch (theme) {
+    case THEMES.LIGHT:
+      return ICONS.sun;
+    case THEMES.DARK:
+      return ICONS.moon;
+    default:
+      return ICONS.system;
+  }
+}
+
+/**
+ * Get label for theme
+ */
+function getLabelForTheme(theme) {
+  switch (theme) {
+    case THEMES.LIGHT:
+      return 'Light';
+    case THEMES.DARK:
+      return 'Dark';
+    default:
+      return 'System';
+  }
+}
+
+// Initialize theme immediately to prevent flash
+initTheme();
+
+// Export for use in modules
+if (typeof window !== 'undefined') {
+  window.ThemeManager = {
+    THEMES,
+    initTheme,
+    applyTheme,
+    setTheme,
+    getStoredTheme,
+    getSystemTheme,
+    getEffectiveTheme,
+    createThemeSelector,
+    setupSystemThemeListener
+  };
+}
+
+// Auto-initialize theme selector when DOM is ready
+(function() {
+  function initThemeUI() {
+    const container = document.getElementById('themeToggle');
+    if (container && window.ThemeManager) {
+      window.ThemeManager.createThemeSelector('themeToggle');
+      window.ThemeManager.setupSystemThemeListener();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initThemeUI);
+  } else {
+    initThemeUI();
+  }
+})();

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1017,8 +1017,8 @@ def generate_docs_html(query_defs: dict, transition_defs: dict) -> str:
 
             <p><strong>Tip:</strong> Examples below execute against Dash Platform Testnet via the Evo SDK client. Click "Run" to invoke any example.</p>
 
-            <div style="background-color: #e3f2fd; padding: 15px; border-radius: 5px; margin-top: 15px;">
-                <strong>Test Identity:</strong> Examples use the testnet identity <code style="background-color: #fff; padding: 2px 6px; border-radius: 3px;">{DEFAULT_TEST_IDENTITY}</code><br>
+            <div class="info-note">
+                <strong>Test Identity:</strong> Examples use the testnet identity <code>{DEFAULT_TEST_IDENTITY}</code><br>
                 This identity has activity on testnet and is safe to use for read-only demonstrations.
             </div>
         </div>'''
@@ -1028,10 +1028,13 @@ def generate_docs_html(query_defs: dict, transition_defs: dict) -> str:
 <head>
     <meta charset=\"UTF-8\">
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+    <meta name=\"theme-color\" content=\"#2c3e50\">
     <title>Dash Platform Evo JS SDK Documentation</title>
     <link rel=\"icon\" type=\"image/svg+xml\" href=\"https://media.dash.org/wp-content/uploads/blue-d.svg\">
     <link rel=\"alternate icon\" type=\"image/png\" href=\"https://media.dash.org/wp-content/uploads/blue-d-250.png\">
+    <link rel=\"stylesheet\" href=\"theme.css\">
     <link rel=\"stylesheet\" href=\"docs.css\">
+    <script src=\"theme.js\"></script>
     <script type=\"module\">
 {textwrap.indent(docs_script, '        ')}
     </script>
@@ -1051,6 +1054,7 @@ def generate_docs_html(query_defs: dict, transition_defs: dict) -> str:
 
     <div class=\"sidebar\">
         <h2>Table of Contents</h2>
+        <div id=\"themeToggle\" class=\"docs-theme-toggle\"></div>
         <div class=\"search-container\">
             <input type=\"text\" id=\"sidebar-search\" class=\"search-input\" placeholder=\"Search queries and transitions...\">
         </div>


### PR DESCRIPTION
Supersedes #32 because I could not push to the original `dashpay:feature/dark-mode` branch from `thepastaclaw`.

What changed here:
- merged current `master` into the dark-mode branch to resolve the `public/index.html` conflict
- preserved the dark-mode/theme wiring from the original branch
- fixed the docs generator so generated `docs.html` also loads `theme.css`/`theme.js` after `docs.css` was switched to theme variables

Validation:
- `python3 scripts/generate_docs.py`
- `python3 scripts/check_documentation.py`
- `npx playwright install chromium`
- `npx playwright test tests/e2e/smoke` *(fails on this host: Chromium headless shell exits with `SIGTRAP` before tests execute)*

Conflict-resolution commit on this branch: `9a02c2c`