### PR TITLE
fix: use semver comparison to avoid downgrade PRs in update-evo-sdk workflow

### DIFF
--- a/.github/workflows/update-evo-sdk.yml
+++ b/.github/workflows/update-evo-sdk.yml
@@ -55,7 +55,7 @@ jobs:
 
           # Only update if the latest stable version is strictly higher than current
           # npx semver returns the version if it satisfies the range, empty otherwise
-          IS_HIGHER=$(npx -y semver "$LATEST_VERSION" -r ">$CURRENT_VERSION" || true)
+          IS_HIGHER=$(npx -y semver@7.7.4 "$LATEST_VERSION" -r ">$CURRENT_VERSION" || true)
 
           if [ -n "$IS_HIGHER" ]; then
             echo "needs_update=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-evo-sdk.yml
+++ b/.github/workflows/update-evo-sdk.yml
@@ -53,13 +53,16 @@ jobs:
           echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Check if versions differ
-          if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
+          # Only update if the latest stable version is strictly higher than current
+          # npx semver returns the version if it satisfies the range, empty otherwise
+          IS_HIGHER=$(npx -y semver "$LATEST_VERSION" -r ">$CURRENT_VERSION" || true)
+
+          if [ -n "$IS_HIGHER" ]; then
             echo "needs_update=true" >> "$GITHUB_OUTPUT"
             echo "New version available: $LATEST_VERSION"
           else
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
-            echo "Already on latest version"
+            echo "Current version ($CURRENT_VERSION) is same or newer than latest ($LATEST_VERSION)"
           fi
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes a bug in the `update-evo-sdk` workflow where a PR would be opened to "downgrade" the SDK when the repo is on a pre-release version (e.g. `3.1-dev.1`) that is ahead of the latest stable release on npm (e.g. `3.0.1`). The workflow now uses semver ordering to only open PRs when the npm version is strictly higher than what's currently in `package.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version comparison logic in build workflow to improve accuracy and robustness of SDK update detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->