### PR TITLE
chore: update to evo-sdk 3.1-dev.6 with platform version pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@dashevo/evo-sdk": "3.1.0-dev.1"
+    "@dashevo/evo-sdk": "3.1.0-dev.6"
   },
   "devDependencies": {
     "@playwright/test": "1.56.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@dashevo/evo-sdk": "3.1.0-dev.6"
+    "@dashevo/evo-sdk": "3.1.0-dev.8"
   },
   "devDependencies": {
     "@playwright/test": "1.56.0",

--- a/public/app.js
+++ b/public/app.js
@@ -576,11 +576,13 @@ function buildClientOptions() {
     proofs: true,
   };
   const { advancedOptions } = state;
-  // TODO: pinned to protocol_version 11 (Platform v3.0.x) because
-  // rs-sdk seeds protocol_version from PlatformVersion::latest() and only
-  // ratchets upward, so an unpinned SDK sends V1-wire GetDocumentsRequest to
-  // v3.0.x testnet and fails to decode. Remove this default once testnet is
-  // on Platform v3.1+ (protocol_version 12).
+  // TODO: pinned to protocol_version 11 (Platform v3.0.x) because rs-sdk
+  // seeds protocol_version from PlatformVersion::latest() and only ratchets
+  // upward, so an unpinned SDK sends V1-wire GetDocumentsRequest to a v3.0.x
+  // network and fails to decode. Applies to both mainnet and testnet — revisit
+  // (remove or bump) once the target networks are on Platform v3.1+
+  // (protocol_version 12). If mainnet and testnet ever sit on different active
+  // protocol versions, this will need to be gated on selectedNetwork instead.
   opts.version = advancedOptions.platformVersion ?? 11;
   const settings = {};
   if (advancedOptions.connectTimeout) settings.connectTimeoutMs = advancedOptions.connectTimeout;

--- a/public/app.js
+++ b/public/app.js
@@ -576,9 +576,12 @@ function buildClientOptions() {
     proofs: true,
   };
   const { advancedOptions } = state;
-  if (advancedOptions.platformVersion) {
-    opts.version = advancedOptions.platformVersion;
-  }
+  // TODO: pinned to protocol_version 11 (Platform v3.0.x) because
+  // rs-sdk seeds protocol_version from PlatformVersion::latest() and only
+  // ratchets upward, so an unpinned SDK sends V1-wire GetDocumentsRequest to
+  // v3.0.x testnet and fails to decode. Remove this default once testnet is
+  // on Platform v3.1+ (protocol_version 12).
+  opts.version = advancedOptions.platformVersion ?? 11;
   const settings = {};
   if (advancedOptions.connectTimeout) settings.connectTimeoutMs = advancedOptions.connectTimeout;
   if (advancedOptions.requestTimeout) settings.timeoutMs = advancedOptions.requestTimeout;

--- a/public/index.html
+++ b/public/index.html
@@ -76,10 +76,10 @@
           <div style="margin-bottom: 10px;">
             <label style="display: block; margin-bottom: 5px; font-weight: 500;">Platform Version:</label>
             <div style="display: flex; gap: 10px; align-items: center;">
-              <input type="number" id="platformVersion" placeholder="Latest" style="flex: 1; padding: 5px;" min="1">
+              <input type="number" id="platformVersion" placeholder="11" style="flex: 1; padding: 5px;" min="1">
               <span id="latestVersionInfo" style="font-size: 0.9em; color: #666;"></span>
             </div>
-            <small style="color: #666;">Leave empty for latest version</small>
+            <small style="color: #666;">Leave empty to use default (currently 11)</small>
           </div>
 
           <details style="margin-top: 10px;">

--- a/tests/e2e/queries/query-execution.spec.js
+++ b/tests/e2e/queries/query-execution.spec.js
@@ -806,15 +806,13 @@ test.describe('Evo SDK Query Execution Tests', () => {
           expect(result).toBeDefined();
           const parsed = JSON.parse(result);
           // In proof mode, data is wrapped in { data, metadata, proof }
-          const epochResult = isProofMode && parsed.data ? parsed.data : parsed;
-          // Result is wrapped in V0 with epoch info
-          expect(epochResult).toHaveProperty('V0');
-          const epochInfo = epochResult.V0;
+          const epochInfo = isProofMode && parsed.data ? parsed.data : parsed;
+          // evo-sdk 3.1+ returns a flat camelCase epoch object (no V0 wrapper).
           expect(epochInfo).toHaveProperty('index');
-          expect(epochInfo).toHaveProperty('first_block_time');
-          expect(epochInfo).toHaveProperty('first_block_height');
-          expect(epochInfo).toHaveProperty('first_core_block_height');
-          expect(epochInfo).toHaveProperty('fee_multiplier_permille');
+          expect(epochInfo).toHaveProperty('firstBlockTime');
+          expect(epochInfo).toHaveProperty('firstBlockHeight');
+          expect(epochInfo).toHaveProperty('firstCoreBlockHeight');
+          expect(epochInfo).toHaveProperty('feeMultiplierPermille');
           expect(typeof epochInfo.index).toBe('number');
           expect(epochInfo.index).toBeGreaterThanOrEqual(0);
         }
@@ -832,16 +830,14 @@ test.describe('Evo SDK Query Execution Tests', () => {
           expect(typeof epochData).toBe('object');
           const keys = Object.keys(epochData);
           expect(keys.length).toBeGreaterThan(0);
-          // Check first epoch structure (wrapped in V0)
+          // evo-sdk 3.1+ returns flat camelCase per-epoch objects (no V0 wrapper).
           const firstKey = keys[0];
-          const firstEpoch = epochData[firstKey];
-          expect(firstEpoch).toHaveProperty('V0');
-          const epochInfo = firstEpoch.V0;
+          const epochInfo = epochData[firstKey];
           expect(epochInfo).toHaveProperty('index');
-          expect(epochInfo).toHaveProperty('first_block_time');
-          expect(epochInfo).toHaveProperty('first_block_height');
-          expect(epochInfo).toHaveProperty('first_core_block_height');
-          expect(epochInfo).toHaveProperty('fee_multiplier_permille');
+          expect(epochInfo).toHaveProperty('firstBlockTime');
+          expect(epochInfo).toHaveProperty('firstBlockHeight');
+          expect(epochInfo).toHaveProperty('firstCoreBlockHeight');
+          expect(epochInfo).toHaveProperty('feeMultiplierPermille');
         }
       },
       {
@@ -858,15 +854,13 @@ test.describe('Evo SDK Query Execution Tests', () => {
           const keys = Object.keys(epochData);
           // Can be empty if no finalized epochs in range
           if (keys.length > 0) {
-            // Check first epoch structure (may or may not be wrapped in V0)
+            // evo-sdk 3.1+ returns flat camelCase per-epoch objects (no V0 wrapper).
             const firstKey = keys[0];
-            const firstEpoch = epochData[firstKey];
-            // Handle both wrapped (V0) and unwrapped formats
-            const epochInfo = firstEpoch.V0 || firstEpoch;
-            expect(epochInfo).toHaveProperty('first_block_time');
-            expect(epochInfo).toHaveProperty('first_block_height');
-            expect(epochInfo).toHaveProperty('first_core_block_height');
-            expect(epochInfo).toHaveProperty('fee_multiplier_permille');
+            const epochInfo = epochData[firstKey];
+            expect(epochInfo).toHaveProperty('firstBlockTime');
+            expect(epochInfo).toHaveProperty('firstBlockHeight');
+            expect(epochInfo).toHaveProperty('firstCoreBlockHeight');
+            expect(epochInfo).toHaveProperty('feeMultiplierPermille');
           }
         }
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,19 +5,19 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@dashevo/evo-sdk@npm:3.1.0-dev.6":
-  version: 3.1.0-dev.6
-  resolution: "@dashevo/evo-sdk@npm:3.1.0-dev.6"
+"@dashevo/evo-sdk@npm:3.1.0-dev.8":
+  version: 3.1.0-dev.8
+  resolution: "@dashevo/evo-sdk@npm:3.1.0-dev.8"
   dependencies:
-    "@dashevo/wasm-sdk": "npm:3.1.0-dev.6"
-  checksum: 10/12615a5198795240f92f2d466c4a829b96aa75905887031933007e47f282f91c5fe9c03796367a80d0c5b1454d3bac897d88b105a2ab6286ccf0b0701e8d74e6
+    "@dashevo/wasm-sdk": "npm:3.1.0-dev.8"
+  checksum: 10/66453475222080ef58123b66e09b421f9787de4fa6b2345b7b10a9391fd506fac95bd869129cdec8d6e487f7367dd3b2a6945f532b660ca576542302055cda92
   languageName: node
   linkType: hard
 
-"@dashevo/wasm-sdk@npm:3.1.0-dev.6":
-  version: 3.1.0-dev.6
-  resolution: "@dashevo/wasm-sdk@npm:3.1.0-dev.6"
-  checksum: 10/587efc9653da61973960c2100aeaa6ae49a1a5340925eab0d70289fc0bf9850bccb37e2d3ff827ef8c4501af9822644cf7b4f2a4dbbbdabac9cbd64eecdc3a4a
+"@dashevo/wasm-sdk@npm:3.1.0-dev.8":
+  version: 3.1.0-dev.8
+  resolution: "@dashevo/wasm-sdk@npm:3.1.0-dev.8"
+  checksum: 10/5f0b5b24c3040604b97fa146ce5c1fae04a1b2624c31c07d3de2a06658e6bd4a7f43840120e65551dd20f075260e234c3523fad8539a47dbc8ccb25e2f4a83da
   languageName: node
   linkType: hard
 
@@ -515,7 +515,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@dashevo/evo-sdk": "npm:3.1.0-dev.6"
+    "@dashevo/evo-sdk": "npm:3.1.0-dev.8"
     "@playwright/test": "npm:1.56.0"
     dotenv: "npm:17.2.3"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,19 +5,19 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@dashevo/evo-sdk@npm:3.1.0-dev.1":
-  version: 3.1.0-dev.1
-  resolution: "@dashevo/evo-sdk@npm:3.1.0-dev.1"
+"@dashevo/evo-sdk@npm:3.1.0-dev.6":
+  version: 3.1.0-dev.6
+  resolution: "@dashevo/evo-sdk@npm:3.1.0-dev.6"
   dependencies:
-    "@dashevo/wasm-sdk": "npm:3.1.0-dev.1"
-  checksum: 10/d83b482bb54077d24829f96cd826a6efa6461c0c9cff6c18b853857f0e62477f0eb4a770541c6ad5f4f83e383482daef59de5104d70e0e0f71b057caf1cd5e21
+    "@dashevo/wasm-sdk": "npm:3.1.0-dev.6"
+  checksum: 10/12615a5198795240f92f2d466c4a829b96aa75905887031933007e47f282f91c5fe9c03796367a80d0c5b1454d3bac897d88b105a2ab6286ccf0b0701e8d74e6
   languageName: node
   linkType: hard
 
-"@dashevo/wasm-sdk@npm:3.1.0-dev.1":
-  version: 3.1.0-dev.1
-  resolution: "@dashevo/wasm-sdk@npm:3.1.0-dev.1"
-  checksum: 10/93482f79c1066c1b62e447c7ccbe357ef089ca73d1a98cc3256882d2298e6ac88bdb89acc0aea14a834cde90cbfc2e8d19f2fe80525193a385b09ecaa2b217e3
+"@dashevo/wasm-sdk@npm:3.1.0-dev.6":
+  version: 3.1.0-dev.6
+  resolution: "@dashevo/wasm-sdk@npm:3.1.0-dev.6"
+  checksum: 10/587efc9653da61973960c2100aeaa6ae49a1a5340925eab0d70289fc0bf9850bccb37e2d3ff827ef8c4501af9822644cf7b4f2a4dbbbdabac9cbd64eecdc3a4a
   languageName: node
   linkType: hard
 
@@ -515,7 +515,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@dashevo/evo-sdk": "npm:3.1.0-dev.1"
+    "@dashevo/evo-sdk": "npm:3.1.0-dev.6"
     "@playwright/test": "npm:1.56.0"
     dotenv: "npm:17.2.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

- Bumps `@dashevo/evo-sdk` from `3.1.0-dev.1` → `3.1.0-dev.8`.
- Pins the platform protocol_version default to `11` (Platform v3.0.x) in `buildClientOptions()` so the SDK emits V0-wire `GetDocumentsRequest` against the live v3.0.1 testnet. Without this pin, the dev.6 SDK defaults to `PlatformVersion::latest()` (v12 / V1 wire) and the network — still on v11 — fails to decode the request, causing every document/DPNS query to return `"could not decode data contracts query"`. The pin disables the SDK's auto-detect ratchet for the session, so it stays on V0 wire even if the network later reports v12. The user-facing Advanced Options override still wins.
- Updates epoch test validators for dev.8's new response shape: epoch objects are now flat camelCase (no `V0` wrapper, `firstBlockTime` instead of `first_block_time`, etc.).

## Follow up

**Once testnet (and eventually mainnet) upgrades to Platform v3.1, revisit this default — likely either remove the pin or bump it to `12` to match the network's active protocol version.**

## Test plan

- [x] `yarn test:queries` — full 109-test query suite passes (previously 18 failing on dev.6, now 0).
- [x] Manual browser smoke: `yarn serve`, run a `getDocuments` query in the UI against testnet — returns a documents array.
- [x] Manual browser smoke: open Advanced Options, set Platform Version to `12`, run a `getDocuments` query — confirms the user override beats the default (will fail against v3.0.1 testnet, which is the expected/correct behavior proving the override path works).
- [x] CI green on the parallel-e2e-tests project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `@dashevo/evo-sdk` to 3.1.0-dev.6.
  * SDK protocol/version now defaults to 11 to avoid mismatches.
  * SDK configuration UI now shows 11 as the placeholder/default guidance.

* **Tests**
  * Updated E2E assertions to match the SDK's new response shape and camelCase field names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/evo-sdk-website/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->