### PR TITLE
chore: update to evo sdk v4.0.0-rc.2 and fix credit withdrawal test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@dashevo/evo-sdk": "4.0.0-beta.2"
+    "@dashevo/evo-sdk": "4.0.0-rc.2"
   },
   "devDependencies": {
     "@playwright/test": "1.56.0",

--- a/tests/e2e/fixtures/test-data.js
+++ b/tests/e2e/fixtures/test-data.js
@@ -643,7 +643,7 @@ const testData = {
           {
             identityId: "7XcruVSsGQVSgTcmPewaE4tXLutnW1F6PXxwMbo8GYQC",
             toAddress: "yQW6TmUFef5CDyhEYwjoN8aUTMmKLYYNDm",
-            amount: 190000, // 0.0000019 DASH in credits (minimum withdrawal amount)
+            amount: 1000000, // 0.00001 DASH in credits (minimum withdrawal amount)
             privateKey: process.env.TEST_PRIVATE_KEY_TRANSFER || "PLACEHOLDER_TRANSFER_KEY",
             description: "Withdraw credits to Dash address"
           }

--- a/tests/e2e/transitions/state-transitions.spec.js
+++ b/tests/e2e/transitions/state-transitions.spec.js
@@ -71,7 +71,7 @@ async function executeWithRetry(executeFn, options = {}) {
 function validateBasicStateTransitionResult(result) {
   // Check for withdrawal-specific minimum amount error
   if (!result.success && result.result && result.result.includes('Missing response message')) {
-    console.error('⚠️  Withdrawal may have failed due to insufficient amount. Minimum withdrawal is ~190,000 credits.');
+    console.error('⚠️  Withdrawal may have failed due to insufficient amount. Minimum withdrawal is 1,000,000 credits.');
     console.error('Full error:', result.result);
   }
 
@@ -576,8 +576,8 @@ test.describe('Evo SDK State Transition Tests', () => {
       const testParams = parameterInjector.testData.stateTransitionParameters.identity.identityCreditWithdrawal.testnet[0];
 
       // Skip test if withdrawal amount is below minimum threshold
-      if (testParams.amount < 190000) {
-        test.skip(true, `Withdrawal amount ${testParams.amount} credits is below minimum threshold (~190,000 credits)`);
+      if (testParams.amount < 1000000) {
+        test.skip(true, `Withdrawal amount ${testParams.amount} credits is below minimum threshold (1,000,000 credits)`);
       }
 
       // Set up the identity credit withdrawal transition

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,19 +5,19 @@ __metadata:
   version: 8
   cacheKey: 10
 
-"@dashevo/evo-sdk@npm:4.0.0-beta.2":
-  version: 4.0.0-beta.2
-  resolution: "@dashevo/evo-sdk@npm:4.0.0-beta.2"
+"@dashevo/evo-sdk@npm:4.0.0-rc.2":
+  version: 4.0.0-rc.2
+  resolution: "@dashevo/evo-sdk@npm:4.0.0-rc.2"
   dependencies:
-    "@dashevo/wasm-sdk": "npm:4.0.0-beta.2"
-  checksum: 10/32603fe2d198a8ade4d2c9190888e164ab0a3d98413a31a3eb081d1e26a644a0580ff7f6323afecea7c9a966341b0736906bd65da7c40d44573bab2d25b9d3c1
+    "@dashevo/wasm-sdk": "npm:4.0.0-rc.2"
+  checksum: 10/236ff1518da57b423a444181b58b25740d7c61e7999861447c6c1b88cc7ce3b3b4c8f9665ca67a989f41b436f81b2ef92f74ee61c5d03f77093d6593e91b5f4e
   languageName: node
   linkType: hard
 
-"@dashevo/wasm-sdk@npm:4.0.0-beta.2":
-  version: 4.0.0-beta.2
-  resolution: "@dashevo/wasm-sdk@npm:4.0.0-beta.2"
-  checksum: 10/2633dbe7865bb3185177d614cbf27214ece5319a87ab4013c1493ae44e64e47d22040a76c592ca5df5a2435cd37e705c05d72fffc3b0a5d3a25db91f9996ea38
+"@dashevo/wasm-sdk@npm:4.0.0-rc.2":
+  version: 4.0.0-rc.2
+  resolution: "@dashevo/wasm-sdk@npm:4.0.0-rc.2"
+  checksum: 10/0b9050cb13bdfeea26f7b64a287eec8d73546f2799263ca21a2ff88188e2ecdba7eaeee005646601122a2fac0142bcc9213b5d302c5a2f2a140c1abe753df86a
   languageName: node
   linkType: hard
 
@@ -515,7 +515,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@dashevo/evo-sdk": "npm:4.0.0-beta.2"
+    "@dashevo/evo-sdk": "npm:4.0.0-rc.2"
     "@playwright/test": "npm:1.56.0"
     dotenv: "npm:17.2.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

- Bump `@dashevo/evo-sdk` (and bundled `@dashevo/wasm-sdk`) from `4.0.0-beta.2` to `4.0.0-rc.2`
- Fix the failing identity credit withdrawal transition test

## Why

The protocol raised the minimum identity credit withdrawal from 190,000 to 1,000,000 credits. The withdrawal transition test still used the old amount, so it failed with:

> Error: Withdrawal failed: Protocol error: Credit withdrawal amount 190000 must be greater or equal to 1000000 and less than 50000000000000

## Changes

- `package.json` / `yarn.lock` — SDK version bump to `4.0.0-rc.2`
- `tests/e2e/fixtures/test-data.js` — withdrawal `amount` raised `190000` → `1000000`
- `tests/e2e/transitions/state-transitions.spec.js` — skip threshold and error hint updated to the new 1,000,000-credit minimum

## Testing

Verified locally


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `@dashevo/evo-sdk` to release candidate version 4.0.0-rc.2

* **Updates**
  * Adjusted minimum identity credit withdrawal amount to 1,000,000 credits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->