### PR TITLE
ci: update GitHub Actions workflows to Node 22 and pin actions by hash

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '20'
+          node-version: '22'
           package-manager-cache: false
 
       - name: Enable Corepack

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout source at tested commit
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
           package-manager-cache: false
@@ -46,7 +46,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -66,10 +66,10 @@ jobs:
           yarn check
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # Upload the public directory
           path: './public'
@@ -85,4 +85,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/test-sdk-site.yml
+++ b/.github/workflows/test-sdk-site.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 
@@ -54,7 +54,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
 
@@ -64,7 +64,7 @@ jobs:
           yarn install
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -96,7 +96,7 @@ jobs:
           yarn test:queries
 
       - name: Upload Playwright Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: playwright-report-${{ inputs.test_type || 'all' }}-${{ inputs.browser || 'chromium' }}-${{ github.run_number }}
@@ -104,7 +104,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: test-results-${{ inputs.test_type || 'all' }}-${{ inputs.browser || 'chromium' }}-${{ github.run_number }}
@@ -114,7 +114,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Screenshots and Videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: test-failures-${{ inputs.test_type || 'all' }}-${{ inputs.browser || 'chromium' }}-${{ github.run_number }}

--- a/.github/workflows/test-sdk-site.yml
+++ b/.github/workflows/test-sdk-site.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/update-evo-sdk.yml
+++ b/.github/workflows/update-evo-sdk.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.check_version.outputs.needs_update == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           draft: ${{ steps.smoke_tests.outcome != 'success' || steps.query_tests.outcome != 'success' }}
           branch: update-deps/evo-sdk-${{ steps.check_version.outputs.latest }}

--- a/.github/workflows/update-evo-sdk.yml
+++ b/.github/workflows/update-evo-sdk.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Summary

Brings all three GitHub Actions workflows up to date:

- **Node 22** — bumps the runner Node version from 20 to 22 across all workflows. Node 20 reaches end-of-life in April 2026; 22 is the active LTS and matches the local development version.
- **Hash-pinned actions** — pins every action to the commit SHA of its latest release. `test-sdk-site.yml` previously used floating major tags (`@v4`/`@v5`) with no hash pinning at all; the other two workflows were pinned but on outdated versions.

## Action version changes

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 (float) / v5.0.0 | v7.0.0 |
| actions/setup-node | v4 (float) / v5.0.0 / v6.0.0 | v6.4.0 |
| actions/setup-python | v5 (float) / v6.0.0 | v6.2.0 |
| actions/cache | v4 (float) | v5.0.5 |
| actions/upload-artifact | v4 (float) | v7.0.1 |
| actions/configure-pages | v5.0.0 | v6.0.0 |
| actions/upload-pages-artifact | v4.0.0 | v5.0.0 |
| actions/deploy-pages | v4.0.5 | v5.0.0 |
| peter-evans/create-pull-request | v7.0.8 | v8.1.1 |

## Notes

- `create-pull-request` v7 → v8 is the one update crossing a notable major boundary (v8 runs on Node 24 on the runner and raises its minimum git version); functionally unchanged for our usage.
- The three `upload-artifact` steps in `test-sdk-site.yml` use distinct artifact names, so the v4+ "no duplicate artifact name" behavior is not a concern.
- All pinned SHAs were verified to resolve to their commented release tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment pipeline dependencies to latest stable versions for improved build reliability and security.
  * Upgraded development Node.js environment from version 20 to 22 across build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->