### PR TITLE
fix(state): clear previous dynamic input handler before replacing it

### DIFF
--- a/public/src/state.js
+++ b/public/src/state.js
@@ -71,6 +71,10 @@ export function clearDynamicHandlers() {
 
 export function registerDynamicHandler(name, handler) {
   if (!name || !handler) return;
+  const previous = dynamicInputHandlers.get(name);
+  if (previous && previous !== handler && typeof previous.clear === 'function') {
+    try { previous.clear(); } catch (_) { /* ignore */ }
+  }
   dynamicInputHandlers.set(name, handler);
 }
 

--- a/tests/unit/dynamic-handlers.test.js
+++ b/tests/unit/dynamic-handlers.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+// state.js touches `document` at import time. The vitest config uses the
+// 'node' environment (no DOM), so we stub a minimal document shim with
+// getElementById/querySelectorAll before dynamically importing the module.
+let registerDynamicHandler;
+let clearDynamicHandlers;
+let dynamicInputHandlers;
+
+beforeAll(async () => {
+  vi.stubGlobal('document', {
+    getElementById: () => null,
+    querySelectorAll: () => [],
+  });
+  ({ registerDynamicHandler, clearDynamicHandlers, dynamicInputHandlers } =
+    await import('../../public/src/state.js'));
+});
+
+describe('registerDynamicHandler — replacing an existing handler', () => {
+  it('calls clear() on the previous handler before replacing it', () => {
+    clearDynamicHandlers();
+    const previousClear = vi.fn();
+    const previous = { clear: previousClear };
+    const next = { clear: vi.fn() };
+
+    registerDynamicHandler('foo', previous);
+    registerDynamicHandler('foo', next);
+
+    expect(previousClear).toHaveBeenCalledTimes(1);
+    expect(dynamicInputHandlers.get('foo')).toBe(next);
+  });
+
+  it('does not invoke clear() when no previous handler is registered', () => {
+    clearDynamicHandlers();
+    const next = { clear: vi.fn() };
+    registerDynamicHandler('bar', next);
+    expect(next.clear).not.toHaveBeenCalled();
+    expect(dynamicInputHandlers.get('bar')).toBe(next);
+  });
+
+  it('skips clear() when re-registering the exact same handler instance', () => {
+    clearDynamicHandlers();
+    const handler = { clear: vi.fn() };
+    registerDynamicHandler('baz', handler);
+    registerDynamicHandler('baz', handler);
+    expect(handler.clear).not.toHaveBeenCalled();
+    expect(dynamicInputHandlers.get('baz')).toBe(handler);
+  });
+
+  it('still registers the new handler when the previous clear() throws', () => {
+    clearDynamicHandlers();
+    const previous = { clear: () => { throw new Error('boom'); } };
+    const next = { clear: vi.fn() };
+    registerDynamicHandler('qux', previous);
+    expect(() => registerDynamicHandler('qux', next)).not.toThrow();
+    expect(dynamicInputHandlers.get('qux')).toBe(next);
+  });
+
+  it('replaces a previous handler that has no clear() method', () => {
+    clearDynamicHandlers();
+    const previous = {};
+    const next = { clear: vi.fn() };
+    registerDynamicHandler('plain', previous);
+    expect(() => registerDynamicHandler('plain', next)).not.toThrow();
+    expect(dynamicInputHandlers.get('plain')).toBe(next);
+  });
+});


### PR DESCRIPTION
## Summary

`registerDynamicHandler(name, handler)` in `public/src/state.js` swapped a new handler into the `dynamicInputHandlers` map without first invoking `clear()` on whatever handler was already registered under that name. If a previous handler had attached listeners or held timers/subscriptions, those resources were stranded — there was no longer a reference to call `clear()` on later.

This change mirrors the existing pattern in `clearDynamicHandlers()`:

- Look up the previous handler before the `set()`.
- If it exists, isn't the same instance, and exposes a `clear()` method, call it.
- Wrap the call in `try { ... } catch (_) { /* ignore */ }` so a buggy previous `clear()` cannot block the new handler from being registered (same convention as `clearDynamicHandlers`).

Fixes dashpay/evo-sdk-website#55

## Changes

- `public/src/state.js` — guard `registerDynamicHandler` against leaking the prior handler (4 added lines).
- `tests/unit/dynamic-handlers.test.js` — new Vitest unit suite covering:
  - clear() is called on the previous handler when replaced
  - clear() is not called when no previous handler exists
  - clear() is skipped when re-registering the exact same instance
  - a throwing previous clear() still allows the new handler to register
  - a previous handler without clear() is replaced cleanly

State.js touches `document` at module load, and the vitest config uses the `node` environment (no DOM). The test stubs a minimal `document` shim via `vi.stubGlobal` before dynamically importing the module — no jsdom dependency needed.

## Validation

- `npx vitest run` → **7 files / 129 tests passed** (5 new tests for this fix; existing 124 still green).
- `npx vitest run tests/unit/dynamic-handlers.test.js` → **5 / 5 passed**.

E2E Playwright suite not run locally — the change is scoped to a pure registration helper covered by the new unit tests.

## Test plan

- [x] Unit tests pass locally (`npx vitest run`).
- [x] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved handler registration system to properly clean up previous handlers when they are replaced, preventing potential resource leaks and improving overall application stability. The system now gracefully handles edge cases where cleanup operations fail or handlers don't support cleanup functionality, ensuring more robust and reliable dynamic handler management throughout the application lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->