### PR TITLE
security(sdk-client): rebuild version info DOM without innerHTML

### DIFF
--- a/public/src/sdk-client.js
+++ b/public/src/sdk-client.js
@@ -2,6 +2,7 @@ import { EvoSDK, wallet, DataContract, Document, IdentitySigner, Identifier } fr
 import { assembleClientOptions } from './client-options.js';
 import { elements, state } from './state.js';
 import { setStatus } from './ui.js';
+import { buildVersionDisplayModel } from './version-display.js';
 
 export function updateNetworkIndicator() {
   const selected = elements.networkRadios.find(r => r.checked)?.value || 'testnet';
@@ -49,6 +50,16 @@ export function applyAdvancedConfig() {
   setStatus('Configuration applied. Reconnect on next request.', 'success');
 }
 
+function createVersionLink(href, text) {
+  const a = document.createElement('a');
+  a.href = href;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  a.style.cssText = 'color: inherit; text-decoration: underline;';
+  a.textContent = text;
+  return a;
+}
+
 export async function loadVersionInfo() {
   try {
     const response = await fetch('version-info.json');
@@ -59,30 +70,17 @@ export async function loadVersionInfo() {
     const versionInfo = await response.json();
     const versionElement = document.getElementById('versionInfo');
     if (versionElement && versionInfo) {
-      const sdkVersion = versionInfo.sdkVersion || 'unknown';
-      const commitHash = versionInfo.commitHash || 'unknown';
-      const buildTime = versionInfo.buildTime || '';
-
-      // Format the build time if available
-      let buildDisplay = '';
-      if (buildTime) {
-        const d = new Date(buildTime);
-        buildDisplay = buildTime && !Number.isNaN(d.getTime()) ? d.toISOString().slice(0, 10) : '';
-      }
-
-      // Create the version display with clickable links
-      const githubUrl = `https://github.com/dashpay/evo-sdk-website/commit/${commitHash}`;
-      const sdkUrl = 'https://www.npmjs.com/package/@dashevo/evo-sdk';
-
-      const linkStyle = 'color: inherit; text-decoration: underline;';
-      versionElement.innerHTML = [
-        `<a href="${sdkUrl}" target="_blank" style="${linkStyle}">v${sdkVersion}↗</a>`,
-        '•',
-        `<a href="${githubUrl}" target="_blank" style="${linkStyle}">${commitHash}↗</a>`,
-        '•',
-        buildDisplay
-      ].join(' ');
-      versionElement.title = `SDK Version: ${sdkVersion}\nWebsite Commit: ${commitHash}\nBuild Time: ${buildTime}`;
+      const model = buildVersionDisplayModel(versionInfo);
+      // Preserve the original " • "-separated layout — including the trailing
+      // separator when buildDisplay is empty — using text nodes so nothing is
+      // ever parsed as HTML (CWE-79).
+      versionElement.replaceChildren(
+        createVersionLink(model.sdkLink.href, model.sdkLink.text),
+        document.createTextNode(' • '),
+        createVersionLink(model.commitLink.href, model.commitLink.text),
+        document.createTextNode(` • ${model.buildDisplay}`),
+      );
+      versionElement.title = model.title;
     }
   } catch (error) {
     console.warn('Could not load version info:', error);

--- a/public/src/version-display.js
+++ b/public/src/version-display.js
@@ -1,0 +1,28 @@
+// Pure helper: turn the raw version-info.json payload into the strings the
+// loadVersionInfo() DOM render needs. Kept side-effect-free and DOM-free so
+// it can be unit-tested in node without jsdom; sdk-client.js owns the actual
+// element construction (programmatic, no innerHTML — see CWE-79 hardening).
+export function buildVersionDisplayModel(versionInfo) {
+  const sdkVersion = versionInfo?.sdkVersion || 'unknown';
+  const commitHash = versionInfo?.commitHash || 'unknown';
+  const buildTime = versionInfo?.buildTime || '';
+
+  let buildDisplay = '';
+  if (buildTime) {
+    const d = new Date(buildTime);
+    buildDisplay = !Number.isNaN(d.getTime()) ? d.toISOString().slice(0, 10) : '';
+  }
+
+  return {
+    sdkLink: {
+      href: 'https://www.npmjs.com/package/@dashevo/evo-sdk',
+      text: `v${sdkVersion}↗`,
+    },
+    commitLink: {
+      href: `https://github.com/dashpay/evo-sdk-website/commit/${commitHash}`,
+      text: `${commitHash}↗`,
+    },
+    buildDisplay,
+    title: `SDK Version: ${sdkVersion}\nWebsite Commit: ${commitHash}\nBuild Time: ${buildTime}`,
+  };
+}

--- a/tests/unit/version-display.test.js
+++ b/tests/unit/version-display.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { buildVersionDisplayModel } from '../../public/src/version-display.js';
+
+// The DOM render in sdk-client.js (loadVersionInfo) is intentionally thin —
+// the textContent / href values it sets come straight from this model. Pinning
+// the model here is what guarantees the XSS-hardened render keeps producing
+// the same user-visible output as the previous innerHTML version.
+
+describe('buildVersionDisplayModel — link targets', () => {
+  it('points the SDK link at the npm package and the commit link at the github commit', () => {
+    const model = buildVersionDisplayModel({
+      sdkVersion: '4.0.0-rc.2',
+      commitHash: 'abc1234',
+      buildTime: '2026-01-15T12:34:56Z',
+    });
+    expect(model.sdkLink.href).toBe('https://www.npmjs.com/package/@dashevo/evo-sdk');
+    expect(model.commitLink.href).toBe('https://github.com/dashpay/evo-sdk-website/commit/abc1234');
+  });
+
+  it('formats the link text with the v-prefix and trailing ↗ glyph', () => {
+    const model = buildVersionDisplayModel({
+      sdkVersion: '4.0.0-rc.2',
+      commitHash: 'abc1234',
+      buildTime: '',
+    });
+    expect(model.sdkLink.text).toBe('v4.0.0-rc.2↗');
+    expect(model.commitLink.text).toBe('abc1234↗');
+  });
+});
+
+describe('buildVersionDisplayModel — buildDisplay', () => {
+  it('formats valid ISO build times as YYYY-MM-DD', () => {
+    expect(buildVersionDisplayModel({ buildTime: '2026-01-15T12:34:56Z' }).buildDisplay)
+      .toBe('2026-01-15');
+  });
+
+  it('drops invalid build times to an empty string', () => {
+    expect(buildVersionDisplayModel({ buildTime: 'not-a-date' }).buildDisplay).toBe('');
+  });
+
+  it('treats missing build time as empty', () => {
+    expect(buildVersionDisplayModel({}).buildDisplay).toBe('');
+  });
+});
+
+describe('buildVersionDisplayModel — defaults and title', () => {
+  it('falls back to "unknown" for missing version and commit', () => {
+    const model = buildVersionDisplayModel({});
+    expect(model.sdkLink.text).toBe('vunknown↗');
+    expect(model.commitLink.text).toBe('unknown↗');
+    expect(model.commitLink.href).toBe('https://github.com/dashpay/evo-sdk-website/commit/unknown');
+  });
+
+  it('handles a null payload without throwing', () => {
+    const model = buildVersionDisplayModel(null);
+    expect(model.sdkLink.text).toBe('vunknown↗');
+    expect(model.buildDisplay).toBe('');
+  });
+
+  it('exposes the multi-line title tooltip with the raw buildTime', () => {
+    const model = buildVersionDisplayModel({
+      sdkVersion: '4.0.0-rc.2',
+      commitHash: 'abc1234',
+      buildTime: '2026-01-15T12:34:56Z',
+    });
+    expect(model.title).toBe(
+      'SDK Version: 4.0.0-rc.2\nWebsite Commit: abc1234\nBuild Time: 2026-01-15T12:34:56Z',
+    );
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
         'public/src/definitions-data.js',
         'public/src/client-options.js',
         'public/src/form/parse-input.js',
+        'public/src/version-display.js',
       ],
     },
   },


### PR DESCRIPTION
## Summary

Closes the CWE-79 sink and unsafe `_blank` anchors flagged in `loadVersionInfo()` (`public/src/sdk-client.js`).

- The `innerHTML` assignment is replaced with programmatic DOM construction. Each anchor is built with `document.createElement('a')`, and `href`, `target='_blank'`, `rel='noopener noreferrer'`, `style.cssText`, and `textContent` are all set programmatically. Separators are `document.createTextNode(' • ')`, and the container is rebuilt with `versionElement.replaceChildren(...)`.
- Rendered output is preserved byte-for-byte vs. the previous `[a1, '•', a2, '•', buildDisplay].join(' ')`, including the trailing `" • "` when `buildDisplay` is empty.
- The string-building portion is extracted to a pure `buildVersionDisplayModel()` helper in a new `public/src/version-display.js` module — same split pattern as `client-options.js` — so it can be exercised in the existing node-only vitest setup without jsdom.
- New `tests/unit/version-display.test.js` (8 cases) pins the link `href` / text (incl. the `↗` glyph), the `YYYY-MM-DD` build date, the title tooltip, and null/missing/invalid-input handling.
- `vitest.config.js` coverage `include` is extended to keep the new module on the scoped coverage list, matching the existing convention.

Acceptance criteria from the issue:

- [x] `versionElement.innerHTML` is not used in `loadVersionInfo()`.
- [x] Both anchor elements have `rel="noopener noreferrer"`.
- [x] Rendered output is visually identical to the previous implementation.

Fixes dashpay/evo-sdk-website#54

## Validation

- `npx vitest run` → 7 test files, 132 tests passed (132 / 132), 124 ms.
- `npx vitest run tests/unit/version-display.test.js` → 1 file, 8 tests passed.
- E2E (Playwright) not run locally — change is scoped to a small, characterization-tested helper plus a DOM-construction rewrite with no behavior change; full E2E runs in CI on PR.

## Test plan

- [ ] CI green on `vitest` and Playwright smoke / queries.
- [ ] Manually inspect the footer "v… • <commit> • <date>" line on the deployed preview to confirm visual parity and that the anchors render with the new `rel` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security of version information display by eliminating raw HTML injection and implementing safer DOM element construction
* **Tests**
  * Added comprehensive test suite for version display functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->